### PR TITLE
Fix for function paren newline linting rule 

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -42,7 +42,6 @@
     "no-unused-vars": ["error", { "vars": "all", "args": "after-used", "ignoreRestSiblings": false }],
     "no-trailing-spaces": ["error", { "skipBlankLines": true }],
     "no-underscore-dangle": "error",
-    "eol-last": ["error", "always"],
-    "function-paren-newline": ["error", "always"]
+    "eol-last": ["error", "always"]
   }
 }

--- a/src/types/index.js
+++ b/src/types/index.js
@@ -8,6 +8,8 @@ export const userType = new GraphQLObjectType({
     id: { type: GraphQLID },
     name: { type: GraphQLString },
     email: { type: GraphQLString },
+    createdAt: { type: GraphQLString },
+    updatedAt: { type: GraphQLString }
   })
 });
 


### PR DESCRIPTION
fix: remove-function-paren-newline / add updatedAt and createdAt to ser type graphql